### PR TITLE
Provide versions plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("com.github.ben-manes.versions") version "0.39.0"
     kotlin("multiplatform") version "1.5.21"
     kotlin("plugin.serialization") version "1.5.21"
     id("org.jlleitschuh.gradle.ktlint") version "10.1.0"


### PR DESCRIPTION
An easy way to check on the cmd line what dependencies/plugins are out of date.
My experience with this is generally positive.

However there are corner cases.  The largest is when defining a `toolVersion` property in a configuration block.  This is purely convention--especially older, more established plugins--, and not visible to the model Gradle builds and hands to the versions plugin.

Example output as of the time of posting this PR:
```
🌼 ./gradlew dependencyUpdates

> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.39.0
 - com.pinterest:ktlint:0.41.0
 - io.kotest:kotest-runner-junit5:4.6.1
 - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1
 - org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2
 - org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:10.1.0

The following dependencies have later milestone versions:
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable [1.5.21 -> 1.5.30-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-serialization [1.5.21 -> 1.5.30-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-serialization-unshaded [1.5.21 -> 1.5.30-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8 [1.5.21 -> 1.5.30-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-js [1.5.21 -> 1.5.30-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin [1.5.21 -> 1.5.30-M1]
 - org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin [1.5.21 -> 1.5.30-M1]

Failed to determine the latest version for the following dependencies (use --info for details):
 - org.jetbrains.kotlin:kotlin-test
     1.5.30-M1

Gradle release-candidate updates:
 - Gradle: [7.1.1: UP-TO-DATE]

Generated report file build/dependencyUpdates/report.txt

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.1.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 33s
```